### PR TITLE
Resolving agents for a channel should ignore the channel's subset (and only rely on provided/ required capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ kind: Agent
 metadata:
   name: acme-billing-agent
   labels:
-    subset: "stable"
     version: "1.0.0"
 spec:
   description: This is the billing agent description

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/generator/RoutingChannelGenerator.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/generator/RoutingChannelGenerator.kt
@@ -24,7 +24,6 @@ object RoutingChannelGenerator {
     fun createChannelRoutingResource(
         channelResource: ChannelResource,
         wiredCapabilities: Set<Wire<AgentResource>>,
-        subset: String,
     ): ChannelRoutingResource {
         val channelRoutingResource = createChannelRoutingResource(channelResource)
         val groupedWires = groupWiresByProvider(wiredCapabilities)
@@ -34,7 +33,7 @@ object RoutingChannelGenerator {
             val capabilityGroup =
                 CapabilityGroup(
                     name = agent.metadata.name,
-                    capabilities = wires.map { ChannelRoutingCapability(it, subset) }.toSet(),
+                    capabilities = wires.map { ChannelRoutingCapability(it) }.toSet(),
                     description = agent.spec.description,
                 )
             capabilityGroups.add(capabilityGroup)

--- a/src/main/kotlin/org/eclipse/lmos/operator/resources/CRD.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resources/CRD.kt
@@ -150,16 +150,14 @@ data class ChannelRoutingCapability(
     var providedVersion: String,
     @Required
     var host: String,
-    var subset: String? = null,
     var description: String = "",
 ) {
-    constructor(wire: Wire<AgentResource>, subset: String?) : this(
+    constructor(wire: Wire<AgentResource>) : this(
         name = wire.providedCapability.name,
         requiredVersion = wire.requiredCapability.version,
         providedVersion = wire.providedCapability.version,
         description = wire.providedCapability.description,
         host = "${wire.provider.metadata.name}.${wire.provider.metadata.namespace}.svc.cluster.local",
-        subset = subset,
     )
 }
 

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/generator/ChannelRoutingGeneratorTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/generator/ChannelRoutingGeneratorTest.kt
@@ -87,7 +87,7 @@ class ChannelRoutingGeneratorTest {
         val channelResource = ChannelResource()
         channelResource.metadata = metadata
 
-        val channelRoutingResource = createChannelRoutingResource(channelResource, wiredCapabilities, "testSubset")
+        val channelRoutingResource = createChannelRoutingResource(channelResource, wiredCapabilities)
 
         assertThat(channelRoutingResource).isNotNull()
         assertThat(channelRoutingResource.metadata).isNotNull()

--- a/src/test/resources/acme-billing-agent-v1.yaml
+++ b/src/test/resources/acme-billing-agent-v1.yaml
@@ -9,7 +9,6 @@ kind: Agent
 metadata:
   name: billing-agent-stable
   labels:
-    subset: "stable"
     version: "1.0.0"
 spec:
   description: This is the billing agent description

--- a/src/test/resources/acme-billing-agent-v2.yaml
+++ b/src/test/resources/acme-billing-agent-v2.yaml
@@ -9,7 +9,6 @@ kind: Agent
 metadata:
   name: billing-agent-canary
   labels:
-    subset: "canary"
     version: "1.1.0"
 spec:
   description: This is the billing agent description

--- a/src/test/resources/acme-contract-agent-v1.yaml
+++ b/src/test/resources/acme-contract-agent-v1.yaml
@@ -9,7 +9,6 @@ kind: Agent
 metadata:
   name: contract-agent
   labels:
-    subset: "stable"
     version: "1.0.0"
 spec:
   description: This is the contract agent description


### PR DESCRIPTION
Resolving agents for a channel should ignore the channel's subset (and only rely on provided/ required capabilities).

In particular, agents do not have a subset, only channels have a subset with the purpose of using separate channels for different queries. If an agent is used to answer a query for a given channel should only rely on the capabilities provided by the agent, and the capabilities required by the channel.

Resolves #43