### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 version = 1
@@ -12,7 +12,7 @@ path = [
     "*.md",
     ".devcontainer/**"
 ]
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/OperatorApplication.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/OperatorApplication.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/OperatorConfig.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/OperatorConfig.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/AgentReconciler.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/AgentReconciler.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelDependentResource.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelDependentResource.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconciler.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconciler.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelRolloutReconciler.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelRolloutReconciler.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/filter/AgentResourcesFilter.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/filter/AgentResourcesFilter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/generator/RoutingChannelGenerator.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/generator/RoutingChannelGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/Resolver.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/Resolver.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/ResolverException.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/ResolverException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/Wire.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/Wire.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolveContext.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolveContext.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolver.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolver.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/CapabilityResolver.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/CapabilityResolver.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/resources/CRD.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resources/CRD.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/server/routing/CustomResourcesController.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/server/routing/CustomResourcesController.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/server/routing/CustomResourcesService.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/server/routing/CustomResourcesService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/kotlin/org/eclipse/lmos/operator/server/routing/impl/DefaultCustomResourcesService.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/server/routing/impl/DefaultCustomResourcesService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
  SPDX-License-Identifier: Apache-2.0
 -->

--- a/src/test/kotlin/org/eclipse/lmos/operator/CustomResourcesControllerIntegrationTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/CustomResourcesControllerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/EnableMockOperator.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/EnableMockOperator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/TestConfig.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/TestConfig.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/data/TestDataGenerator.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/data/TestDataGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/generator/ChannelRoutingGeneratorTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/generator/ChannelRoutingGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentResolveContextTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentResolveContextTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentResolverTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentWireTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resolver/AgentWireTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resolver/CapabilityResolverTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resolver/CapabilityResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resources/agent/AgentResourceTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resources/agent/AgentResourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resources/agent/ProvidedCapabilityTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resources/agent/ProvidedCapabilityTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/kotlin/org/eclipse/lmos/operator/resources/channel/RequiredCapabilityTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/resources/channel/RequiredCapabilityTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/resources/acme-billing-agent-v1.yaml
+++ b/src/test/resources/acme-billing-agent-v1.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/acme-billing-agent-v2.yaml
+++ b/src/test/resources/acme-billing-agent-v2.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/acme-contract-agent-v1.yaml
+++ b/src/test/resources/acme-contract-agent-v1.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/acme-ivr-channel-v1.yaml
+++ b/src/test/resources/acme-ivr-channel-v1.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/acme-ivr-channel-v2.yaml
+++ b/src/test/resources/acme-ivr-channel-v2.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/acme-web-channel-v1.yaml
+++ b/src/test/resources/acme-web-channel-v1.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/channel-routing.yaml
+++ b/src/test/resources/channel-routing.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/src/test/resources/globex-web-channel-v1.yaml
+++ b/src/test/resources/globex-web-channel-v1.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
See https://www.eclipse.org/projects/handbook/#ip-copyright-headers