### PR TITLE
React to Agent updates to ensure dynamic Channel resolution

### DIFF
--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconciler.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconciler.kt
@@ -10,7 +10,14 @@ import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl
+import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent
+import io.javaoperatorsdk.operator.processing.event.ResourceID
+import io.javaoperatorsdk.operator.processing.event.source.EventSource
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource
+import org.eclipse.lmos.operator.resources.AgentResource
 import org.eclipse.lmos.operator.resources.ChannelResource
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -18,7 +25,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ControllerConfiguration(dependents = [Dependent(type = ChannelDependentResource::class)])
-class ChannelReconciler : Reconciler<ChannelResource> {
+class ChannelReconciler : Reconciler<ChannelResource>, EventSourceInitializer<ChannelResource> {
     private val log: Logger = LoggerFactory.getLogger(javaClass)
 
     override fun reconcile(
@@ -34,4 +41,25 @@ class ChannelReconciler : Reconciler<ChannelResource> {
 
         return UpdateControl.patchStatus(channelResource)
     }
+
+    override fun prepareEventSources(context: EventSourceContext<ChannelResource>): Map<String, EventSource> {
+        val config = InformerConfiguration
+            .from(AgentResource::class.java)
+            .withSecondaryToPrimaryMapper { agent ->
+                context.client.resources(ChannelResource::class.java)
+                    // At this point, AgentResourcesFilter could be used to find the matching Channels for the given Agent.
+                    // However, this filter cannot be used due to an edge case: if a supportedChannel or supportedTenant is
+                    // removed from the Agent, the filter will no longer match, and the affected Channels won't be reconciled.
+                    // As a result, such Channels may remain in an incorrect RESOLVED state. To address this, all Channels
+                    // in the namespace are considered to ensure proper reconciliation.
+                    // This edge case could only be fixed within the JOSDK. The InformerEventSource would need to provide
+                    // the old Agent object to the withSecondaryToPrimaryMapper method, enabling proper handling of such cases.
+                    .inNamespace(agent.metadata.namespace).list().items
+                    .map { ResourceID(it.metadata.name, it.metadata.namespace) }
+                    .toSet()
+            }
+            .build()
+        return EventSourceInitializer.nameEventSources(InformerEventSource(config, context))
+    }
+
 }

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
@@ -223,7 +223,176 @@ internal class ChannelReconcilerTest {
         assertThat(channelRoutingResource.metadata.ownerReferences).hasSize(1)
     }
 
+    @Test
+    fun `should resolve Channel again if Agent was added later`() {
+        // When I add one Agent
+        client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel
+        client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
+
+        // Then the Channel is UNRESOLVED, because the required capabilities are not present
+        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status != null },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
+
+        // When I add another Agent with the missing capabilities
+        client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
+
+        // Then the Channel is RESOLVED, because all required capabilities are present
+        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.UNRESOLVED },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+    }
+
+    @Test
+    fun `should resolve Channel again if Agent was removed`() {
+        // When I create two Agents
+        client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel
+        client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
+
+        // Then the Channel is RESOLVED, because all required capabilities are present
+        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status != null },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+
+        // When I remove one Agent
+        client.load(getResource("acme-contract-agent-v1.yaml")).delete()
+
+        // Then the Channel is UNRESOLVED, because the required capabilities are not present anymore
+        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.RESOLVED },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
+    }
+
+
+    @Test
+    fun `should resolve Channel again if Agent was updated`() {
+        // When I create two Agents
+        client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel
+        client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
+
+        // Then the Channel is RESOLVED, because the required capabilities are present
+        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status != null },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+
+        // When I update one Agent that no longer contains the required capability
+        client.load(getResource("acme-contract-agent-v2.yaml")).createOrReplace()
+
+        // Then the Channel is UNRESOLVED, because the required capability is not present anymore
+        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.RESOLVED },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
+    }
+
+    @Test
+    fun `should update Channel Routing capabilities if Agent was updated with new capability version`() {
+        // When I create two Agents
+        client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel
+        client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
+
+        // Then the Channel is RESOLVED, because the required capabilities are present
+        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status != null },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+
+        // and the Channel Routing contains the capability 'download-bill' in version '1.1.0'
+        var channelRoutingResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelRoutingResource::class.java).list().items },
+                { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
+            )
+        assertThat(channelRoutingResources).isNotNull()
+        var channelRoutingResource = channelRoutingResources.find { it.metadata.name == "acme-ivr-stable" }
+        assertThat(channelRoutingResource).isNotNull()
+        var capabilityGroup = channelRoutingResource?.spec?.capabilityGroups?.find { it.name == "billing-agent-stable" }
+        assertThat(capabilityGroup).isNotNull()
+        var capability = capabilityGroup?.capabilities?.find { it.name == "download-bill" }
+        assertThat(capability).isNotNull()
+        assertThat(capability?.providedVersion).isEqualTo("1.1.0")
+
+        // When I update the Agent 'download-bill' capability to version '1.2.0'
+        client.load(getResource("acme-billing-agent-v2.yaml")).createOrReplace()
+
+        // Then the Channel is still RESOLVED
+        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelResource::class.java).list().items },
+                { c: List<ChannelResource> -> c[0].status != null },
+            )
+        assertThat(channelResources).isNotNull().hasSize(1)
+        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
+        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+
+        // and the Channel Routing contains the capability 'download-bill' in version '1.2.0'
+        channelRoutingResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                { client.resources(ChannelRoutingResource::class.java).list().items },
+                { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
+            )
+        assertThat(channelRoutingResources).isNotNull()
+        channelRoutingResource = channelRoutingResources.find { it.metadata.name == "acme-ivr-stable" }
+        assertThat(channelRoutingResource).isNotNull()
+        capabilityGroup = channelRoutingResource?.spec?.capabilityGroups?.find { it.name == "billing-agent-stable" }
+        assertThat(capabilityGroup).isNotNull()
+        capability = capabilityGroup?.capabilities?.find { it.name == "download-bill" }
+        assertThat(capability).isNotNull()
+        assertThat(capability?.providedVersion).isEqualTo("1.2.0")
+    }
+
     private fun getResource(resourceName: String): FileInputStream {
         return FileInputStream(ResourceUtils.getFile("classpath:$resourceName"))
     }
+
 }

--- a/src/test/resources/acme-billing-agent-v2.yaml
+++ b/src/test/resources/acme-billing-agent-v2.yaml
@@ -7,7 +7,7 @@
 apiVersion: lmos.eclipse/v1
 kind: Agent
 metadata:
-  name: billing-agent-canary
+  name: billing-agent-stable
   labels:
     version: "1.1.0"
 spec:
@@ -19,7 +19,7 @@ spec:
     - ivr
   providedCapabilities:
     - name: view-bill
-      version: 1.1.0
+      version: 1.0.0
       description: Capability to view a bill
     - name: download-bill
       version: 1.2.0

--- a/src/test/resources/acme-contract-agent-v2.yaml
+++ b/src/test/resources/acme-contract-agent-v2.yaml
@@ -1,0 +1,23 @@
+#
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: lmos.eclipse/v1
+kind: Agent
+metadata:
+  name: contract-agent
+  labels:
+    version: "1.0.0"
+spec:
+  description: This is the contract agent description
+  supportedTenants:
+    - acme
+  supportedChannels:
+    - web
+    - ivr
+  providedCapabilities:
+    - name: cancel-contract
+      version: 1.1.0
+      description: Capability to cancel a contract


### PR DESCRIPTION
React to Agent updates to ensure dynamic Channel resolution (by using JOSDK event sources). (#50)

Ensure the operator dynamically resolves Channel requirements when Agents are installed, updated, or deleted. This prevents unresolved or incorrectly resolved Channels and ensures consistent behavior as Agents change over time.