### PR TITLE
Ensure correct Channel Routing updates when Agents or capabilities are removed 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,6 +206,10 @@ dependencies {
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation(kotlin("stdlib-jdk8"))
+
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:k3s:1.20.4")
+    testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelDependentResource.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/ChannelDependentResource.kt
@@ -7,7 +7,6 @@
 package org.eclipse.lmos.operator.reconciler
 
 import io.javaoperatorsdk.operator.api.reconciler.Context
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.BooleanWithUndefined
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import org.eclipse.lmos.operator.reconciler.filter.AgentResourcesFilter
@@ -19,12 +18,11 @@ import org.eclipse.lmos.operator.resources.AgentResource
 import org.eclipse.lmos.operator.resources.ChannelResource
 import org.eclipse.lmos.operator.resources.ChannelRoutingResource
 import org.eclipse.lmos.operator.resources.ChannelStatus
-import org.eclipse.lmos.operator.resources.Labels
 import org.eclipse.lmos.operator.resources.ResolveStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-@KubernetesDependent(useSSA = BooleanWithUndefined.FALSE)
+@KubernetesDependent
 class ChannelDependentResource :
     CRUDKubernetesDependentResource<ChannelRoutingResource, ChannelResource>(ChannelRoutingResource::class.java) {
     private val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -63,10 +61,11 @@ class ChannelDependentResource :
         } catch (e: ResolverException) {
             // ChannelRoutingResource must be created because this method is not allowed to return null or throw an exception :(
             val channelRoutingResource =
-                RoutingChannelGenerator.createChannelRoutingResource(channelResource, emptySet())
+                RoutingChannelGenerator.createChannelRoutingResource(channelResource, e.getResolvedWireCapabilities())
             log.error("Resolve failed for channel ${channelResource.metadata.name} in namespace $namespace", e)
             channelResource.status = ChannelStatus(ResolveStatus.UNRESOLVED, e.getUnresolvedRequiredCapabilities())
             return channelRoutingResource
         }
     }
+
 }

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/ResolverException.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/ResolverException.kt
@@ -6,6 +6,7 @@
 
 package org.eclipse.lmos.operator.resolver
 
+import org.eclipse.lmos.operator.resources.AgentResource
 import org.eclipse.lmos.operator.resources.RequiredCapability
 import java.util.Collections
 
@@ -18,39 +19,45 @@ import java.util.Collections
  * [.getUnresolvedRequiredCapabilities] method.
  */
 class ResolverException : Exception {
+    private val resolvedWiredCapabilities: Set<Wire<AgentResource>>
     private val unresolvedRequiredCapabilities: Set<RequiredCapability>
 
     /**
-     * Create a `ResolutionException` with the specified unresolved required capabilities.
+     * Create a [ResolverException] with the wired and unresolved capabilities.
      *
+     * @param resolvedWiredCapabilities The resolved wired capabilities.
      * @param unresolvedRequiredCapabilities The unresolved required capabilities.
      */
-    constructor(unresolvedRequiredCapabilities: Set<RequiredCapability>) : super(
+    constructor(resolvedWiredCapabilities: Set<Wire<AgentResource>>, unresolvedRequiredCapabilities: Set<RequiredCapability>) : super(
         "Required capabilities not resolved: ${unresolvedRequiredCapabilities.joinToString(", ") { it.toString() }}"
     ) {
+        this.resolvedWiredCapabilities = resolvedWiredCapabilities
         this.unresolvedRequiredCapabilities = Collections.unmodifiableSet(unresolvedRequiredCapabilities)
     }
 
     /**
-     * Create a `ResolutionException` with the specified cause.
+     * Create a [ResolverException] with the specified cause.
      *
      * @param cause The cause of this exception.
      */
     constructor(cause: Throwable?) : super(cause) {
+        this.resolvedWiredCapabilities = emptySet()
         this.unresolvedRequiredCapabilities = emptySet()
     }
 
     /**
-     * Create a `ResolutionException` with the specified message, cause, and unresolved required capabilities.
+     * Create a [ResolverException] with the specified message, cause, wired and unresolved capabilities.
      *
      * @param message The message.
      * @param cause The cause of this exception.
+     * @param resolvedWiredCapabilities The resolved wired capabilities.
      * @param unresolvedRequiredCapabilities The unresolved required capabilities.
      */
-    constructor(message: String, cause: Throwable, unresolvedRequiredCapabilities: Set<RequiredCapability>) : super(
+    constructor(message: String, cause: Throwable, resolvedWiredCapabilities: Set<Wire<AgentResource>>, unresolvedRequiredCapabilities: Set<RequiredCapability>) : super(
         message,
         cause
     ) {
+        this.resolvedWiredCapabilities = resolvedWiredCapabilities
         this.unresolvedRequiredCapabilities = Collections.unmodifiableSet(unresolvedRequiredCapabilities)
     }
 
@@ -63,5 +70,15 @@ class ResolverException : Exception {
      */
     fun getUnresolvedRequiredCapabilities(): Set<RequiredCapability> {
         return unresolvedRequiredCapabilities
+    }
+
+    /**
+     * Return the resolved wired capabilities, if any, for this exception.
+     *
+     * @return A collection of the resolved wired capabilities for this exception.
+     * The returned collection may be empty if no wired capabilities are available.
+     */
+    fun getResolvedWireCapabilities(): Set<Wire<AgentResource>> {
+        return resolvedWiredCapabilities
     }
 }

--- a/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolver.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/resolver/impl/AgentResolver.kt
@@ -23,7 +23,7 @@ class AgentResolver : Resolver<AgentResource> {
         val agentResources = resolveContext.availableResources
 
         if (agentResources.isEmpty()) {
-            throw ResolverException(requiredCapabilities)
+            throw ResolverException(emptySet(), requiredCapabilities)
         }
 
         val bestMatchingCapabilities = mutableSetOf<Wire<AgentResource>>()
@@ -49,7 +49,7 @@ class AgentResolver : Resolver<AgentResource> {
             },
         )
         if (unresolvedRequiredCapabilities.isNotEmpty()) {
-            throw ResolverException(unresolvedRequiredCapabilities)
+            throw ResolverException(bestMatchingCapabilities, unresolvedRequiredCapabilities)
         }
 
         return bestMatchingCapabilities

--- a/src/test/kotlin/org/eclipse/lmos/operator/CustomResourcesControllerIntegrationTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/CustomResourcesControllerIntegrationTest.kt
@@ -7,12 +7,12 @@
 package org.eclipse.lmos.operator
 
 import io.fabric8.kubernetes.client.KubernetesClient
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient
 import org.assertj.core.api.Assertions
 import org.eclipse.lmos.operator.resources.ChannelResource
 import org.eclipse.lmos.operator.resources.ChannelRoutingResource
 import org.eclipse.lmos.operator.server.routing.X_NAMESPACE_HEADER
 import org.eclipse.lmos.operator.server.routing.X_SUBSET_HEADER
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
@@ -42,6 +42,12 @@ class CustomResourcesControllerIntegrationTest {
     @Autowired
     private lateinit var client: KubernetesClient
 
+    @AfterEach
+    fun cleanUp() {
+        client.resources(ChannelResource::class.java).delete()
+        client.resources(ChannelRoutingResource::class.java).delete()
+    }
+
     @Test
     fun shouldReturnChannels() {
         // Given I create two Channel resources
@@ -54,7 +60,7 @@ class CustomResourcesControllerIntegrationTest {
                 .get()
                 .uri("/apis/v1/tenants/acme/channels")
                 .header(X_SUBSET_HEADER, "stable")
-                .header(X_NAMESPACE_HEADER, "test")
+                .header(X_NAMESPACE_HEADER, "default")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(ChannelResource::class.java).returnResult()
@@ -76,7 +82,7 @@ class CustomResourcesControllerIntegrationTest {
                 .get()
                 .uri("/apis/v1/tenants/acme/channels/web")
                 .header(X_SUBSET_HEADER, "stable")
-                .header(X_NAMESPACE_HEADER, "test")
+                .header(X_NAMESPACE_HEADER, "default")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChannelResource::class.java).returnResult()
@@ -99,7 +105,7 @@ class CustomResourcesControllerIntegrationTest {
                 .get()
                 .uri("/apis/v1/tenants/acme/channels/web/routing")
                 .header(X_SUBSET_HEADER, "stable")
-                .header(X_NAMESPACE_HEADER, "test")
+                .header(X_NAMESPACE_HEADER, "default")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChannelRoutingResource::class.java).returnResult()
@@ -121,7 +127,7 @@ class CustomResourcesControllerIntegrationTest {
             .get()
             .uri("/apis/v1/tenants/de/channels/unknown/routing")
             .header(X_SUBSET_HEADER, "stable")
-            .header(X_NAMESPACE_HEADER, "test")
+            .header(X_NAMESPACE_HEADER, "default")
             .exchange()
             .expectStatus().isNotFound()
     }

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/ChannelReconcilerTest.kt
@@ -7,15 +7,11 @@
 package org.eclipse.lmos.operator.reconciler
 
 import io.fabric8.kubernetes.client.KubernetesClient
-import io.fabric8.kubernetes.client.utils.Serialization
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility
 import org.eclipse.lmos.operator.EnableMockOperator
 import org.eclipse.lmos.operator.OperatorApplication
-import org.eclipse.lmos.operator.resources.AgentResource
-import org.eclipse.lmos.operator.resources.ChannelResource
-import org.eclipse.lmos.operator.resources.ChannelRoutingResource
-import org.eclipse.lmos.operator.resources.ResolveStatus
+import org.eclipse.lmos.operator.resources.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -49,7 +45,7 @@ internal class ChannelReconcilerTest {
     }
 
     @Test
-    fun verifyThatCRDAreCreated() {
+    fun `verify that CRDs are created`() {
         assertThat(
             client
                 .apiextensions()
@@ -69,158 +65,73 @@ internal class ChannelReconcilerTest {
                 .get(),
         )
             .isNotNull()
+
+        assertThat(
+            client
+                .apiextensions()
+                .v1()
+                .customResourceDefinitions()
+                .withName("channelroutings.lmos.eclipse")
+                .get(),
+        )
+            .isNotNull()
     }
 
     @Test
-    fun shouldCreateResolvedChannelRouting() {
+    fun `should create resolved Channel and ChannelRouting`() {
         // When I create two Agents
-
         client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
         client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
-
-        // When I create a Channel the Reconciler should start
+        // ... and a Channel
         client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
 
-        // Then the channel status should be updated to resolved
-        val channelResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelResource::class.java,
-                        ).list().items
-                    },
-                    { c: List<ChannelResource> -> c[0].status != null },
-                )
+        // Then the Channel is RESOLVED, because the required capabilities are present
+        val channelResource = assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
+        assertThat(channelResource.status.unresolvedRequiredCapabilities).isEmpty()
 
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
-
-        // And the channel routing resource should be created and status is resolved
-        var channelRoutingResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelRoutingResource::class.java,
-                        ).list().items
-                    },
-                    { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-                )
-
-        assertThat(channelRoutingResources).hasSize(1)
-        val channelRoutingResource = channelRoutingResources[0]
-        // assertThat(channelRoutingResource.getStatus().getResolveStatus()).isEqualTo(ResolveStatus.RESOLVED);
-        assertThat(channelRoutingResource.metadata.name).isEqualTo("acme-ivr-stable")
+        // and the Channel Routing contains the expected capabilities
+        val channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
         assertThat(channelRoutingResource.metadata.ownerReferences).hasSize(1)
-        println(Serialization.asYaml(channelRoutingResource))
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityExists(channelRoutingResource, "contract-agent", "view-contract", "1.1.0")
 
         // If I delete the ChannelRoutingResource the desired state is reconciled again
         client.resources(ChannelRoutingResource::class.java).delete()
-        channelRoutingResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelRoutingResource::class.java,
-                        ).list().items
-                    },
-                    { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-                )
-
-        assertThat(channelRoutingResources).hasSize(1)
+        assertThatChannelRoutingExists("acme-ivr-stable")
     }
 
     @Test
-    fun shouldCreateUnresolvedChannelRouting() {
-        // When I create an Agent and a Channel
-
+    fun `should create unresolved Channel and ChannelRouting in case of not matching capabilities`() {
+        // When I create an Agent
         client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel
         client.load(getResource("acme-web-channel-v1.yaml")).createOrReplace()
 
-        // Then the channel status should be updated to unresolved
-        val channelResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelResource::class.java,
-                        ).list().items
-                    },
-                    { c: List<ChannelResource> -> c[0].status != null },
-                )
+        // Then the Channel is UNRESOLVED, because the required capability is not present
+        val channelResource = assertThatChannelExists("acme-web-stable", ResolveStatus.UNRESOLVED)
+        assertThat(channelResource.status.unresolvedRequiredCapabilities).isNotEmpty()
 
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
-
-        // And the channel routing resource should be created but status is unresolved
-        val channelRoutingResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelRoutingResource::class.java,
-                        ).list().items
-                    },
-                    { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-                )
-
-        assertThat(channelRoutingResources).isNotNull().hasSize(1)
-        val channelRoutingResource = channelRoutingResources[0]
-        // assertThat(channelRoutingResource.getStatus().getResolveStatus()).isEqualTo(ResolveStatus.UNRESOLVED);
-        assertThat(channelRoutingResource.metadata.name).isEqualTo("acme-web-stable")
-        assertThat(channelRoutingResource.metadata.ownerReferences).hasSize(1)
+        // and the Channel Routing contains the expected capabilities
+        val channelRoutingResource = assertThatChannelRoutingExists("acme-web-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityGroupNotExists(channelRoutingResource, "contract-agent")
     }
 
     @Test
-    fun shouldCreateUnresolvedChannelRoutingForNotMatchingTenant() {
-        // When I create an Agent and a Channel with different tenants
-
+    fun `should create unresolved Channel and ChannelRouting in case of not matching tenant`() {
+        // When I create an Agent
         client.load(getResource("acme-billing-agent-v1.yaml")).createOrReplace()
+        // ... and a Channel with different tenants
         client.load(getResource("globex-web-channel-v1.yaml")).createOrReplace()
 
-        // Then the channel status should be updated to unresolved
-        val channelResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelResource::class.java,
-                        ).list().items
-                    },
-                    { c: List<ChannelResource> -> c[0].status != null },
-                )
+        // Then the Channel is UNRESOLVED, because the tenant is not matching
+        val channelResource = assertThatChannelExists("globex-web-stable", ResolveStatus.UNRESOLVED)
+        assertThat(channelResource.status.unresolvedRequiredCapabilities).isNotEmpty()
 
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
-
-        // And the channel routing resource should be created but status is unresolved
-        val channelRoutingResources =
-            Awaitility.await().atMost(5, TimeUnit.SECONDS) // Timeout duration
-                .pollInterval(50, TimeUnit.MILLISECONDS) // Polling interval
-                .until(
-                    {
-                        client.resources(
-                            ChannelRoutingResource::class.java,
-                        ).list().items
-                    },
-                    { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-                )
-
-        assertThat(channelRoutingResources).isNotNull().hasSize(1)
-        val channelRoutingResource = channelRoutingResources[0]
-        // assertThat(channelRoutingResource.getStatus().getResolveStatus()).isEqualTo(ResolveStatus.UNRESOLVED);
-        assertThat(channelRoutingResource.metadata.name).isEqualTo("globex-web-stable")
-        assertThat(channelRoutingResource.metadata.ownerReferences).hasSize(1)
+        // And the Channel routing resource should be created
+        assertThatChannelRoutingExists("globex-web-stable")
     }
 
     @Test
@@ -231,29 +142,25 @@ internal class ChannelReconcilerTest {
         client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
 
         // Then the Channel is UNRESOLVED, because the required capabilities are not present
-        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status != null },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.UNRESOLVED)
+
+        // and the Channel Routing contains the expected capabilities
+        var channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityGroupNotExists(channelRoutingResource, "contract-agent")
 
         // When I add another Agent with the missing capabilities
         client.load(getResource("acme-contract-agent-v1.yaml")).createOrReplace()
 
         // Then the Channel is RESOLVED, because all required capabilities are present
-        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.UNRESOLVED },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
+
+        // and the Channel Routing contains the expected capabilities
+        channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityExists(channelRoutingResource, "contract-agent", "view-contract", "1.1.0")
     }
 
     @Test
@@ -265,31 +172,26 @@ internal class ChannelReconcilerTest {
         client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
 
         // Then the Channel is RESOLVED, because all required capabilities are present
-        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status != null },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
+
+        // and the Channel Routing contains the expected capabilities
+        var channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityExists(channelRoutingResource, "contract-agent", "view-contract", "1.1.0")
 
         // When I remove one Agent
         client.load(getResource("acme-contract-agent-v1.yaml")).delete()
 
         // Then the Channel is UNRESOLVED, because the required capabilities are not present anymore
-        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.RESOLVED },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
-    }
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.UNRESOLVED)
 
+        // and the Channel Routing contains the expected capabilities
+        channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityGroupNotExists(channelRoutingResource, "contract-agent")
+    }
 
     @Test
     fun `should resolve Channel again if Agent was updated`() {
@@ -300,29 +202,25 @@ internal class ChannelReconcilerTest {
         client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
 
         // Then the Channel is RESOLVED, because the required capabilities are present
-        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status != null },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
+
+        // and the Channel Routing contains the expected capabilities
+        var channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityExists(channelRoutingResource, "contract-agent", "view-contract", "1.1.0")
 
         // When I update one Agent that no longer contains the required capability
         client.load(getResource("acme-contract-agent-v2.yaml")).createOrReplace()
 
         // Then the Channel is UNRESOLVED, because the required capability is not present anymore
-        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status.resolveStatus != ResolveStatus.RESOLVED },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.UNRESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isNotEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.UNRESOLVED)
+
+        // and the Channel Routing contains the expected capabilities
+        channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "view-bill", "1.0.0")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
+        assertThatCapabilityGroupNotExists(channelRoutingResource, "contract-agent")
     }
 
     @Test
@@ -334,65 +232,66 @@ internal class ChannelReconcilerTest {
         client.load(getResource("acme-ivr-channel-v1.yaml")).createOrReplace()
 
         // Then the Channel is RESOLVED, because the required capabilities are present
-        var channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status != null },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
 
         // and the Channel Routing contains the capability 'download-bill' in version '1.1.0'
-        var channelRoutingResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelRoutingResource::class.java).list().items },
-                { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-            )
-        assertThat(channelRoutingResources).isNotNull()
-        var channelRoutingResource = channelRoutingResources.find { it.metadata.name == "acme-ivr-stable" }
-        assertThat(channelRoutingResource).isNotNull()
-        var capabilityGroup = channelRoutingResource?.spec?.capabilityGroups?.find { it.name == "billing-agent-stable" }
-        assertThat(capabilityGroup).isNotNull()
-        var capability = capabilityGroup?.capabilities?.find { it.name == "download-bill" }
-        assertThat(capability).isNotNull()
-        assertThat(capability?.providedVersion).isEqualTo("1.1.0")
+        var channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.1.0")
 
         // When I update the Agent 'download-bill' capability to version '1.2.0'
         client.load(getResource("acme-billing-agent-v2.yaml")).createOrReplace()
 
         // Then the Channel is still RESOLVED
-        channelResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelResource::class.java).list().items },
-                { c: List<ChannelResource> -> c[0].status != null },
-            )
-        assertThat(channelResources).isNotNull().hasSize(1)
-        assertThat(channelResources[0].status.resolveStatus).isEqualTo(ResolveStatus.RESOLVED)
-        assertThat(channelResources[0].status.unresolvedRequiredCapabilities).isEmpty()
+        assertThatChannelExists("acme-ivr-stable", ResolveStatus.RESOLVED)
 
-        // and the Channel Routing contains the capability 'download-bill' in version '1.2.0'
-        channelRoutingResources = Awaitility.await().atMost(5, TimeUnit.SECONDS)
-            .pollInterval(50, TimeUnit.MILLISECONDS)
-            .until(
-                { client.resources(ChannelRoutingResource::class.java).list().items },
-                { r: List<ChannelRoutingResource> -> r.isNotEmpty() },
-            )
-        assertThat(channelRoutingResources).isNotNull()
-        channelRoutingResource = channelRoutingResources.find { it.metadata.name == "acme-ivr-stable" }
-        assertThat(channelRoutingResource).isNotNull()
-        capabilityGroup = channelRoutingResource?.spec?.capabilityGroups?.find { it.name == "billing-agent-stable" }
-        assertThat(capabilityGroup).isNotNull()
-        capability = capabilityGroup?.capabilities?.find { it.name == "download-bill" }
-        assertThat(capability).isNotNull()
-        assertThat(capability?.providedVersion).isEqualTo("1.2.0")
+        // and the Channel Routing contains the updated capability 'download-bill' in version '1.2.0'
+        channelRoutingResource = assertThatChannelRoutingExists("acme-ivr-stable")
+        assertThatCapabilityExists(channelRoutingResource, "billing-agent-stable", "download-bill", "1.2.0")
     }
 
     private fun getResource(resourceName: String): FileInputStream {
         return FileInputStream(ResourceUtils.getFile("classpath:$resourceName"))
     }
+
+    private fun assertThatChannelExists(channelName: String, expectedStatus: ResolveStatus) =
+        Awaitility.await("ChannelResource '$channelName' with expected status '$expectedStatus' not found.")
+            .atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                {
+                    client.resources(ChannelResource::class.java).list().items
+                        .find { it.metadata.name == channelName }
+                },
+                { resource: ChannelResource? ->
+                    resource?.status != null && resource.status.resolveStatus == expectedStatus
+                }
+            )!!
+
+    private fun assertThatChannelRoutingExists(channelRoutingName: String) =
+        Awaitility.await("ChannelRoutingResource '$channelRoutingName' not found.")
+            .atMost(5, TimeUnit.SECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
+            .until(
+                {
+                    client.resources(ChannelRoutingResource::class.java).list().items
+                        .find { it.metadata.name == channelRoutingName }
+                },
+                { resource: ChannelRoutingResource? -> resource != null }
+            )!!
+
+    private fun assertThatCapabilityExists(
+        channelRoutingResource: ChannelRoutingResource,
+        agentName: String,
+        capabilityName: String,
+        capabilityVersion: String
+    ) {
+        val capabilityGroup = channelRoutingResource.spec?.capabilityGroups?.find { it.name == agentName }
+        assertThat(capabilityGroup).isNotNull()
+        val capability = capabilityGroup?.capabilities?.find { it.name == capabilityName && it.providedVersion == capabilityVersion }
+        assertThat(capability).isNotNull()
+    }
+
+    private fun assertThatCapabilityGroupNotExists(channelRoutingResource: ChannelRoutingResource, agentName: String) =
+        assertThat(channelRoutingResource.spec?.capabilityGroups?.find { it.name == agentName }).isNull()
 
 }

--- a/src/test/resources/channel-routing.yaml
+++ b/src/test/resources/channel-routing.yaml
@@ -15,7 +15,7 @@ metadata:
     subset: "stable"
     version: "1.0.0"
   name: "acme-web-stable"
-  namespace: "test"
+  namespace: "default"
   ownerReferences:
     - apiVersion: "lmos.eclipse/v1"
       kind: "Channel"


### PR DESCRIPTION
**Fix Channel Routing inconsistencies by enabling Server-Side Apply (SSA), improve integration testing**  (#55)

The Channel Routing is not updated correctly when capabilities are removed from Agents or when Agents are completely uninstalled. This issue occurred because Server-Side Apply (SSA) was disabled and the fallback matching algorithm did not correctly detect these changes. By enabling SSA, the Channel Routing resource now correctly reflects the resolved capabilities.  

Since the Fabric8 Kubernetes Mock Server [does not support SSA](https://github.com/fabric8io/kubernetes-client/issues/5337), the integration tests now run against a real Kubernetes cluster using Testcontainers with the K3s module. This ensures more realistic and reliable tests, bringing us closer to real-world Kubernetes behavior.