### PR TITLE
fix: Add label filter for services in KubernetesResourceManager

### DIFF
--- a/src/main/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManager.kt
+++ b/src/main/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManager.kt
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.StatusDetails
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.fabric8.kubernetes.client.KubernetesClient
+import org.eclipse.lmos.operator.reconciler.LABEL_SELECTOR
 import org.eclipse.lmos.operator.resources.AgentResource
 import org.eclipse.lmos.operator.resources.RolloutResource
 import org.slf4j.LoggerFactory
@@ -107,6 +108,7 @@ class KubernetesResourceManager(
             kubernetesClient
                 .services()
                 .inNamespace(deployment.metadata.namespace)
+                .withLabelSelector(LABEL_SELECTOR)
                 .list()
 
         val matchingServices =
@@ -138,6 +140,7 @@ class KubernetesResourceManager(
             kubernetesClient
                 .services()
                 .inNamespace(rollout.metadata.namespace)
+                .withLabelSelector(LABEL_SELECTOR)
                 .list()
 
         val matchingServices =

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManagerTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManagerTest.kt
@@ -155,7 +155,13 @@ class KubernetesResourceManagerTest {
             }
 
         val serviceList = ServiceList().apply { items = listOf(service) }
-        every { kubernetesClient.services().inNamespace("my-namespace").withLabelSelector(LABEL_SELECTOR).list() } returns serviceList
+        every {
+            kubernetesClient
+                .services()
+                .inNamespace("my-namespace")
+                .withLabelSelector(LABEL_SELECTOR)
+                .list()
+        } returns serviceList
 
         // when
         val url = underTest.getServiceUrl(deployment, "/capabilities")
@@ -207,7 +213,13 @@ class KubernetesResourceManagerTest {
             }
 
         val serviceList = ServiceList().apply { items = listOf(service) }
-        every { kubernetesClient.services().inNamespace("my-namespace").withLabelSelector(LABEL_SELECTOR).list() } returns serviceList
+        every {
+            kubernetesClient
+                .services()
+                .inNamespace("my-namespace")
+                .withLabelSelector(LABEL_SELECTOR)
+                .list()
+        } returns serviceList
 
         // when-then
         assertThatThrownBy { underTest.getServiceUrl(deployment, "/capabilities") }

--- a/src/test/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManagerTest.kt
+++ b/src/test/kotlin/org/eclipse/lmos/operator/reconciler/k8s/KubernetesResourceManagerTest.kt
@@ -26,6 +26,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.eclipse.lmos.operator.reconciler.LABEL_SELECTOR
 import org.eclipse.lmos.operator.resources.AgentResource
 import org.junit.jupiter.api.Test
 
@@ -138,6 +139,7 @@ class KubernetesResourceManagerTest {
                     ObjectMeta().apply {
                         name = "my-service"
                         namespace = "my-namespace"
+                        labels = mapOf("lmos-agent" to "true")
                     }
                 spec =
                     ServiceSpec().apply {
@@ -153,7 +155,7 @@ class KubernetesResourceManagerTest {
             }
 
         val serviceList = ServiceList().apply { items = listOf(service) }
-        every { kubernetesClient.services().inNamespace("my-namespace").list() } returns serviceList
+        every { kubernetesClient.services().inNamespace("my-namespace").withLabelSelector(LABEL_SELECTOR).list() } returns serviceList
 
         // when
         val url = underTest.getServiceUrl(deployment, "/capabilities")
@@ -205,7 +207,7 @@ class KubernetesResourceManagerTest {
             }
 
         val serviceList = ServiceList().apply { items = listOf(service) }
-        every { kubernetesClient.services().inNamespace("my-namespace").list() } returns serviceList
+        every { kubernetesClient.services().inNamespace("my-namespace").withLabelSelector(LABEL_SELECTOR).list() } returns serviceList
 
         // when-then
         assertThatThrownBy { underTest.getServiceUrl(deployment, "/capabilities") }


### PR DESCRIPTION
The operator was listing all services in a namespace when resolving the .well-known/capabilities.json URL, meaning it could inadvertently contact services unrelated to LMOS agents.